### PR TITLE
Add verify collection instruction

### DIFF
--- a/program/metaplex/token_metadata/instruction.go
+++ b/program/metaplex/token_metadata/instruction.go
@@ -641,3 +641,74 @@ func CreateMetadataAccountV3(param CreateMetadataAccountV3Param) types.Instructi
 		Data: data,
 	}
 }
+
+type SetAndVerifyCollectionParams struct {
+	Metadata                       common.PublicKey
+	CollectionAuthority            common.PublicKey
+	Payer                          common.PublicKey
+	UpdateAuthority                common.PublicKey
+	CollectionMint                 common.PublicKey
+	Collection                     common.PublicKey
+	CollectionMasterEditionAccount common.PublicKey
+	CollectionAuthorityRecord      *common.PublicKey
+}
+
+func CreateSetAndVerifyCollection(param SetAndVerifyCollectionParams) types.Instruction {
+	data, err := borsh.Serialize(struct {
+		Instruction Instruction
+	}{
+		Instruction: InstructionSetAndVerifyCollection,
+	})
+	if err != nil {
+		panic(err)
+	}
+	accounts := []types.AccountMeta{
+		{
+			PubKey:     param.Metadata,
+			IsWritable: true,
+			IsSigner:   false,
+		},
+		{
+			PubKey:     param.CollectionAuthority,
+			IsWritable: true,
+			IsSigner:   true,
+		},
+		{
+			PubKey:     param.Payer,
+			IsWritable: true,
+			IsSigner:   true,
+		},
+		{
+			PubKey:     param.UpdateAuthority,
+			IsWritable: false,
+			IsSigner:   false,
+		},
+		{
+			PubKey:     param.CollectionMint,
+			IsWritable: false,
+			IsSigner:   false,
+		},
+		{
+			PubKey:     param.Collection,
+			IsWritable: false,
+			IsSigner:   false,
+		},
+		{
+			PubKey:     param.CollectionMasterEditionAccount,
+			IsWritable: false,
+			IsSigner:   false,
+		},
+	}
+	if param.CollectionAuthorityRecord != nil {
+		accounts = append(accounts, types.AccountMeta{
+			PubKey:     *param.CollectionAuthorityRecord,
+			IsWritable: false,
+			IsSigner:   false,
+		})
+	}
+	return types.Instruction{
+		ProgramID: common.MetaplexTokenMetaProgramID,
+		Accounts:  accounts,
+		Data:      data,
+	}
+}

--- a/program/metaplex/token_metadata/instruction.go
+++ b/program/metaplex/token_metadata/instruction.go
@@ -642,6 +642,63 @@ func CreateMetadataAccountV3(param CreateMetadataAccountV3Param) types.Instructi
 	}
 }
 
+type VerifyCollectionParams struct {
+	Metadata                       common.PublicKey
+	CollectionAuthority            common.PublicKey
+	Payer                          common.PublicKey
+	CollectionMint                 common.PublicKey
+	Collection                     common.PublicKey
+	CollectionMasterEditionAccount common.PublicKey
+}
+
+func CreateVerifyCollection(param VerifyCollectionParams) types.Instruction {
+	data, err := borsh.Serialize(struct {
+		Instruction Instruction
+	}{
+		Instruction: InstructionVerifyCollection,
+	})
+	if err != nil {
+		panic(err)
+	}
+	accounts := []types.AccountMeta{
+		{
+			PubKey:     param.Metadata,
+			IsWritable: true,
+			IsSigner:   false,
+		},
+		{
+			PubKey:     param.CollectionAuthority,
+			IsWritable: true,
+			IsSigner:   true,
+		},
+		{
+			PubKey:     param.Payer,
+			IsWritable: true,
+			IsSigner:   true,
+		},
+		{
+			PubKey:     param.CollectionMint,
+			IsWritable: false,
+			IsSigner:   false,
+		},
+		{
+			PubKey:     param.Collection,
+			IsWritable: false,
+			IsSigner:   false,
+		},
+		{
+			PubKey:     param.CollectionMasterEditionAccount,
+			IsWritable: false,
+			IsSigner:   false,
+		},
+	}
+	return types.Instruction{
+		ProgramID: common.MetaplexTokenMetaProgramID,
+		Accounts:  accounts,
+		Data:      data,
+	}
+}
+
 type SetAndVerifyCollectionParams struct {
 	Metadata                       common.PublicKey
 	CollectionAuthority            common.PublicKey


### PR DESCRIPTION
When we create a nft and add it to a collection , this instruction can verify the nft as the member of the collection.