### PR TITLE
Fix versioned message serialization: validate version <= 127 to avoid overflow

### DIFF
--- a/types/message.go
+++ b/types/message.go
@@ -76,7 +76,7 @@ func (m *Message) Serialize() ([]byte, error) {
 		if err != nil || versionNum > 255 {
 			return nil, fmt.Errorf("failed to parse message version")
 		}
-		if versionNum > 128 {
+		if versionNum > 127 {
 			return nil, fmt.Errorf("unexpected message version")
 		}
 		b = append([]byte{byte(versionNum + 128)}, b...)


### PR DESCRIPTION
This PR fixes an edge-case in types.Message.Serialize() when encoding versioned messages. The current check allows versionNum == 128, but the encoding uses byte(versionNum + 128), which overflows to 0 and produces an invalid/legacy-looking prefix.

Changes:
- Tighten validation to 0 <= versionNum <= 127 (7-bit version field) before prefixing with 0x80.

This aligns with Solana’s versioned message format where the MSB is a flag and the remaining 7 bits encode the version.