### PR TITLE
fix: always advance past 32-byte authority field in DeserializeLookupTable

### DIFF
--- a/program/address_lookup_table/state.go
+++ b/program/address_lookup_table/state.go
@@ -76,9 +76,11 @@ func DeserializeLookupTable(data []byte, accountOwner common.PublicKey) (Address
 		current += 1
 		if some {
 			pubkey := common.PublicKeyFromBytes(data[current : current+32])
-			current += 32
 			addressLookupTable.Authority = &pubkey
 		}
+		// The on-chain format always writes 32 bytes for the authority pubkey
+		// (zeros when None), so we must always advance past them.
+		current += 32
 
 		addressLookupTable.padding = binary.LittleEndian.Uint16(data[current : current+2])
 		current += 2

--- a/program/address_lookup_table/state_test.go
+++ b/program/address_lookup_table/state_test.go
@@ -96,6 +96,46 @@ func TestDeserializeLookupTable(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name: "authority_none",
+			args: args{
+				// On-chain layout: Authority = None (flag=0, 32 zero bytes still present)
+				// [0:4]   ProgramState = 1 (LookupTable)
+				// [4:12]  DeactivationSlot = max uint64
+				// [12:20] LastExtendedSlot = 0
+				// [20:21] LastExtendedSlotStartIndex = 0
+				// [21:22] HasAuthority = 0 (None)
+				// [22:54] Authority pubkey = 32 zero bytes
+				// [54:56] Padding = 0
+				// [56:88] Address 0 = TokenProgramID
+				data: append(
+					// 56-byte header
+					[]byte{
+						1, 0, 0, 0, // ProgramState = LookupTable
+						255, 255, 255, 255, 255, 255, 255, 255, // DeactivationSlot = max
+						0, 0, 0, 0, 0, 0, 0, 0, // LastExtendedSlot = 0
+						0,                               // LastExtendedSlotStartIndex
+						0,                               // HasAuthority = None
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // Authority (zeros)
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // Authority (zeros)
+						0, 0, // Padding
+					},
+					// 1 address: TokenProgramID
+					common.TokenProgramID.Bytes()...,
+				),
+				accountOwner: common.AddressLookupTableProgramID,
+			},
+			want: AddressLookupTable{
+				ProgramState:               ProgramStateLookupTable,
+				DeactivationSlot:           ^uint64(0),
+				LastExtendedSlot:           0,
+				LastExtendedSlotStartIndex: 0,
+				Authority:                  nil,
+				padding:                    0,
+				Addresses:                  []common.PublicKey{common.TokenProgramID},
+			},
+			wantErr: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

`DeserializeLookupTable` incorrectly parses Address Lookup Tables when `Authority` is `None`. The on-chain format always writes 32 bytes for the `Option<Pubkey>` authority field (zeros when None), but the current code only advances the offset when the option flag is `1` (Some).

This causes:
- An extra phantom address (SystemProgram / all zeros) at index 0
- All real addresses shifted by +1 position
- `N+1` addresses parsed instead of `N`

## Root Cause

```go
// state.go:75-81
some := bool(data[current] == 1)
current += 1
if some {
    pubkey := common.PublicKeyFromBytes(data[current : current+32])
    current += 32  // ← only advances when Some
    addressLookupTable.Authority = &pubkey
}
```

When `some == false`, the 32-byte authority field is not skipped, so `current` is at offset 22 instead of 54. The subsequent padding read and address parsing all start from wrong offsets.

## Fix

Unconditionally advance `current` by 32 after reading the option flag, matching the on-chain layout where `LOOKUP_TABLE_META_SIZE` is always 56 bytes:

```go
some := bool(data[current] == 1)
current += 1
if some {
    pubkey := common.PublicKeyFromBytes(data[current : current+32])
    addressLookupTable.Authority = &pubkey
}
current += 32  // always advance past the 32-byte authority field
```

This is consistent with how other Go Solana SDKs handle this (e.g., [gagliardetto/solana-go](https://github.com/gagliardetto/solana-go) calls `decoder.Discard(32)` in the None branch).

## Testing

- Added `authority_none` test case to `TestDeserializeLookupTable`
- All existing tests continue to pass
- Verified against real mainnet ALT `7Vyx1y8vG9e9Q1MedmXpopRC6ZhVaZzGcvYh5Z3Cs75i` (Orca Whirlpool, 254 entries, Authority=None)

## Impact

Any V0 transaction using an ALT where Authority is None will have its addresses misresolved. This affects DeFi protocols (Orca, Jupiter, etc.) where ALTs commonly have no authority set.