### PR TITLE
Use unit64 for pre/postBalances to be SVM compatable

### DIFF
--- a/client/rpc_get_block_test.go
+++ b/client/rpc_get_block_test.go
@@ -91,14 +91,14 @@ func TestClient_BlockWithConfig(t *testing.T) {
 							Meta: &TransactionMeta{
 								Err: nil,
 								Fee: 10000,
-								PreBalances: []int64{
+								PreBalances: []uint64{
 									499999845001,
 									1000000000000000,
 									143487360,
 									1169280,
 									1,
 								},
-								PostBalances: []int64{
+								PostBalances: []uint64{
 									499999835001,
 									1000000000000000,
 									143487360,

--- a/client/rpc_get_transaction.go
+++ b/client/rpc_get_transaction.go
@@ -42,8 +42,8 @@ func (t Transaction) Version() types.MessageVersion {
 type TransactionMeta struct {
 	Err                  any
 	Fee                  uint64
-	PreBalances          []int64
-	PostBalances         []int64
+	PreBalances          []uint64
+	PostBalances         []uint64
 	PreTokenBalances     []rpc.TransactionMetaTokenBalance
 	PostTokenBalances    []rpc.TransactionMetaTokenBalance
 	LogMessages          []string

--- a/client/rpc_get_transaction_test.go
+++ b/client/rpc_get_transaction_test.go
@@ -90,7 +90,7 @@ func TestClient_GetTransaction(t *testing.T) {
 							"Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL consumed 27016 of 200000 compute units",
 							"Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success",
 						},
-						PreBalances: []int64{
+						PreBalances: []uint64{
 							38026659881,
 							0,
 							1461600,
@@ -99,7 +99,7 @@ func TestClient_GetTransaction(t *testing.T) {
 							1,
 							898174080,
 						},
-						PostBalances: []int64{
+						PostBalances: []uint64{
 							38024615601,
 							2039280,
 							1461600,
@@ -191,12 +191,12 @@ func TestClient_GetTransaction(t *testing.T) {
 							"Program H7WBiBDaZpWwGfhPLmXrdD3r86d6eQfzb184a2arM7Bm consumed 32192 of 200000 compute units",
 							"Program H7WBiBDaZpWwGfhPLmXrdD3r86d6eQfzb184a2arM7Bm success",
 						},
-						PreBalances: []int64{
+						PreBalances: []uint64{
 							109107171519,
 							1,
 							1141440,
 						},
-						PostBalances: []int64{
+						PostBalances: []uint64{
 							109107166519,
 							1,
 							1141440,
@@ -253,7 +253,7 @@ func TestClient_GetTransaction(t *testing.T) {
 					Meta: &TransactionMeta{
 						Err: nil,
 						Fee: 5000,
-						PreBalances: []int64{
+						PreBalances: []uint64{
 							112595193235,
 							2039280,
 							934087680,
@@ -263,7 +263,7 @@ func TestClient_GetTransaction(t *testing.T) {
 							1461600,
 							1461600,
 						},
-						PostBalances: []int64{
+						PostBalances: []uint64{
 							112595188235,
 							2039280,
 							934087680,

--- a/rpc/get_block_test.go
+++ b/rpc/get_block_test.go
@@ -46,14 +46,14 @@ func TestGetBlock(t *testing.T) {
 								Meta: &TransactionMeta{
 									Err: nil,
 									Fee: 10000,
-									PreBalances: []int64{
+									PreBalances: []uint64{
 										499999845001,
 										1000000000000000,
 										143487360,
 										1169280,
 										1,
 									},
-									PostBalances: []int64{
+									PostBalances: []uint64{
 										499999835001,
 										1000000000000000,
 										143487360,
@@ -132,14 +132,14 @@ func TestGetBlock(t *testing.T) {
 								Meta: &TransactionMeta{
 									Err: nil,
 									Fee: 10000,
-									PreBalances: []int64{
+									PreBalances: []uint64{
 										499999845001,
 										1000000000000000,
 										143487360,
 										1169280,
 										1,
 									},
-									PostBalances: []int64{
+									PostBalances: []uint64{
 										499999835001,
 										1000000000000000,
 										143487360,
@@ -202,14 +202,14 @@ func TestGetBlock(t *testing.T) {
 								Meta: &TransactionMeta{
 									Err: nil,
 									Fee: 10000,
-									PreBalances: []int64{
+									PreBalances: []uint64{
 										499999845001,
 										1000000000000000,
 										143487360,
 										1169280,
 										1,
 									},
-									PostBalances: []int64{
+									PostBalances: []uint64{
 										499999835001,
 										1000000000000000,
 										143487360,
@@ -380,14 +380,14 @@ func TestGetBlock(t *testing.T) {
 								Meta: &TransactionMeta{
 									Err: nil,
 									Fee: 10000,
-									PreBalances: []int64{
+									PreBalances: []uint64{
 										499999845001,
 										1000000000000000,
 										143487360,
 										1169280,
 										1,
 									},
-									PostBalances: []int64{
+									PostBalances: []uint64{
 										499999835001,
 										1000000000000000,
 										143487360,
@@ -468,12 +468,12 @@ func TestGetBlock(t *testing.T) {
 								Meta: &TransactionMeta{
 									Err: nil,
 									Fee: 5000,
-									PreBalances: []int64{
+									PreBalances: []uint64{
 										10000000000000,
 										1,
 										0,
 									},
-									PostBalances: []int64{
+									PostBalances: []uint64{
 										9998999995000,
 										1,
 										1000000000,
@@ -503,12 +503,12 @@ func TestGetBlock(t *testing.T) {
 								Meta: &TransactionMeta{
 									Err: nil,
 									Fee: 5000,
-									PreBalances: []int64{
+									PreBalances: []uint64{
 										9998999995000,
 										1000000000,
 										1,
 									},
-									PostBalances: []int64{
+									PostBalances: []uint64{
 										9997999990000,
 										2000000000,
 										1,
@@ -536,12 +536,12 @@ func TestGetBlock(t *testing.T) {
 								Meta: &TransactionMeta{
 									Err: nil,
 									Fee: 10000,
-									PreBalances: []int64{
+									PreBalances: []uint64{
 										499765110000,
 										1000000000000000,
 										1,
 									},
-									PostBalances: []int64{
+									PostBalances: []uint64{
 										499765100000,
 										1000000000000000,
 										1,
@@ -607,11 +607,11 @@ func TestGetBlock(t *testing.T) {
 								Meta: &TransactionMeta{
 									Err: nil,
 									Fee: 5000,
-									PreBalances: []int64{
+									PreBalances: []uint64{
 										20000000000,
 										1141440,
 									},
-									PostBalances: []int64{
+									PostBalances: []uint64{
 										19999995000,
 										1141440,
 									},
@@ -644,12 +644,12 @@ func TestGetBlock(t *testing.T) {
 								Meta: &TransactionMeta{
 									Err: nil,
 									Fee: 10000,
-									PreBalances: []int64{
+									PreBalances: []uint64{
 										499998892500,
 										1000000000000000,
 										1,
 									},
-									PostBalances: []int64{
+									PostBalances: []uint64{
 										499998882500,
 										1000000000000000,
 										1,

--- a/rpc/get_transaction.go
+++ b/rpc/get_transaction.go
@@ -19,8 +19,8 @@ type GetTransaction struct {
 type TransactionMeta struct {
 	Err                  any                               `json:"err"`
 	Fee                  uint64                            `json:"fee"`
-	PreBalances          []int64                           `json:"preBalances"`
-	PostBalances         []int64                           `json:"postBalances"`
+	PreBalances          []uint64                          `json:"preBalances"`
+	PostBalances         []uint64                          `json:"postBalances"`
 	PreTokenBalances     []TransactionMetaTokenBalance     `json:"preTokenBalances"`
 	PostTokenBalances    []TransactionMetaTokenBalance     `json:"postTokenBalances"`
 	Rewards              []Reward                          `json:"rewards"`

--- a/rpc/get_transaction_test.go
+++ b/rpc/get_transaction_test.go
@@ -78,7 +78,7 @@ func TestGetTransaction(t *testing.T) {
 								"Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success",
 							},
 							Rewards: []Reward{},
-							PreBalances: []int64{
+							PreBalances: []uint64{
 								38026659881,
 								0,
 								1461600,
@@ -87,7 +87,7 @@ func TestGetTransaction(t *testing.T) {
 								1,
 								898174080,
 							},
-							PostBalances: []int64{
+							PostBalances: []uint64{
 								38024615601,
 								2039280,
 								1461600,
@@ -211,7 +211,7 @@ func TestGetTransaction(t *testing.T) {
 								"Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success",
 							},
 							Rewards: []Reward{},
-							PreBalances: []int64{
+							PreBalances: []uint64{
 								38026659881,
 								0,
 								1461600,
@@ -220,7 +220,7 @@ func TestGetTransaction(t *testing.T) {
 								1,
 								898174080,
 							},
-							PostBalances: []int64{
+							PostBalances: []uint64{
 								38024615601,
 								2039280,
 								1461600,
@@ -293,11 +293,11 @@ func TestGetTransaction(t *testing.T) {
 						Meta: &TransactionMeta{
 							Err: nil,
 							Fee: 5000,
-							PreBalances: []int64{
+							PreBalances: []uint64{
 								34358794287,
 								1141440,
 							},
-							PostBalances: []int64{
+							PostBalances: []uint64{
 								34358789287,
 								1141440,
 							},
@@ -354,7 +354,7 @@ func TestGetTransaction(t *testing.T) {
 						Meta: &TransactionMeta{
 							Err: nil,
 							Fee: 5000,
-							PreBalances: []int64{
+							PreBalances: []uint64{
 								112595193235,
 								2039280,
 								934087680,
@@ -364,7 +364,7 @@ func TestGetTransaction(t *testing.T) {
 								1461600,
 								1461600,
 							},
-							PostBalances: []int64{
+							PostBalances: []uint64{
 								112595188235,
 								2039280,
 								934087680,


### PR DESCRIPTION
Solana has a max token supply that fits inside an int64 but other SVMs (like Fogo) don't have the same guarantees. preBalances and postBalances should be modeled as unit64s instead of int64s to account for this